### PR TITLE
#6/auth / FE 회원가입 및 로그인 로직 구현

### DIFF
--- a/api/apiClient.ts
+++ b/api/apiClient.ts
@@ -1,0 +1,23 @@
+import axios from "axios";
+
+const BASE_URL = "http://localhost:8080";
+
+// instance axios
+const apiClient = axios.create({
+  baseURL: BASE_URL,
+  timeout: 1500,
+});
+
+// request interceptors
+apiClient.interceptors.request.use(
+  // 요청 전달이 되기 전에 수행되는 로직
+  function async(config) {
+    return config;
+  },
+  // 요청 오류가 있을 시 수행되는 로직
+  function (error) {
+    return Promise.reject(error);
+  }
+);
+
+export default apiClient;

--- a/api/auth.ts
+++ b/api/auth.ts
@@ -1,0 +1,16 @@
+import apiClient from "./apiClient";
+
+interface dataProps {
+  [key: string]: string;
+}
+export const postSignup = async (signupData: dataProps) => {
+  const { data } = await apiClient.post("/signup", signupData);
+
+  return data;
+};
+
+export const postSignin = async (signinData: dataProps) => {
+  const { data } = await apiClient.post("/signin", signinData);
+
+  return data;
+};

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,0 +1,3 @@
+import { postSignup } from "./user";
+
+export { postSignup };

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,3 +1,3 @@
-import { postSignup } from "./user";
+import { postSignup, postSignin } from "./auth";
 
-export { postSignup };
+export { postSignup, postSignin };

--- a/api/user.ts
+++ b/api/user.ts
@@ -1,0 +1,7 @@
+import apiClient from "./apiClient";
+
+export const postSignup = async (signupData: any) => {
+  const { data } = await apiClient.post("/signup", signupData);
+
+  return data;
+};

--- a/api/user.ts
+++ b/api/user.ts
@@ -1,7 +1,0 @@
-import apiClient from "./apiClient";
-
-export const postSignup = async (signupData: any) => {
-  const { data } = await apiClient.post("/signup", signupData);
-
-  return data;
-};

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,4 @@
 "use client";
-import { usePathname, useRouter } from "next/navigation";
-import { useLayoutEffect } from "react";
 import { ThemeProvider } from "@emotion/react";
 import { GlobalStyle, theme } from "style";
 
@@ -9,18 +7,6 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const pathname = usePathname();
-  const router = useRouter();
-
-  useLayoutEffect(() => {
-    const isLogged = !!localStorage.getItem("isLogged");
-    if (pathname === "/" || pathname === "/login") {
-      isLogged && router.push("/stack");
-    } else {
-      !isLogged && router.push("/");
-    }
-  }, []);
-
   return (
     <html lang="ko">
       <head>

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState } from "react";
 import { SignupTemplate } from "component";
+import { postSignup } from "api";
 
 // Input values 초기값들
 const initValue = {
@@ -23,8 +24,9 @@ export default function SignupPage() {
   };
 
   // submit button 클릭
-  const onSubmit = () => {
-    alert(JSON.stringify(values));
+  const onSubmit = async () => {
+    const res = await postSignup(values);
+    console.log("signup response :", res);
   };
 
   return (

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,32 +1,108 @@
 "use client";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { SignupTemplate } from "component";
 import { postSignup } from "api";
 
-// Input values 초기값들
+// inputValues 초기값들
 const initValue = {
-  id: "",
-  pw: "",
-  pwConfirm: "",
-  nickname: "",
+  id: { value: "", isAlert: false },
+  pw: { value: "", isAlert: false },
+  pwConfirm: { value: "", isAlert: false },
+  nickname: { value: "", isAlert: false },
 };
 
 export default function SignupPage() {
+  const router = useRouter();
   const [values, setValues] = useState(initValue);
 
-  // 변경된 input 값 state화
-  const onChange = (type: string, value: string) => {
+  // input alert 관리 함수
+  const setAlert = (type: "id" | "pw" | "pwConfirm" | "nickname" | "all") => {
+    const nextValues = {
+      id: { value: values.id.value, isAlert: false },
+      pw: { value: values.pw.value, isAlert: false },
+      pwConfirm: { value: values.pwConfirm.value, isAlert: false },
+      nickname: { value: values.nickname.value, isAlert: false },
+    };
+    // type이 all일 때
+    if (type === "all") {
+      setValues(() => nextValues);
+      return;
+    }
+
+    // type이 all 외의 나머지일 때
+    nextValues[type].isAlert = true;
+    setValues(() => nextValues);
+  };
+
+  // 변경된 input 값 state 관리 함수
+  const onChange = (
+    type: "id" | "pw" | "pwConfirm" | "nickname",
+    value: string
+  ) => {
+    const nextData = {
+      ...values[type],
+      value,
+    };
     const nextValues = {
       ...values,
-      [type]: value,
+      [type]: nextData,
     };
     setValues(() => nextValues);
   };
 
-  // submit button 클릭
+  // 서버로 데이터를 보내는 것을 관리하는 함수
   const onSubmit = async () => {
-    const res = await postSignup(values);
-    console.log("signup response :", res);
+    const { id, pw, pwConfirm, nickname } = values;
+
+    // 아이디가 4글자 이상 10글자 이하인지 확인
+    if (id.value.length < 4 || id.value.length > 10) {
+      setAlert("id");
+      return;
+    }
+
+    // 비밀번호가 8글자 이상 15글자 이하인지 확인
+    if (pw.value.length < 8 || pw.value.length > 15) {
+      setAlert("pw");
+      return;
+    }
+
+    // 두 비밀번호가 같은지 확인
+    if (pw.value !== pwConfirm.value) {
+      setAlert("pwConfirm");
+      return;
+    }
+
+    // 닉네임이 2글자 이상 8글자 이하인지 확인
+    if (nickname.value.length < 2 || nickname.value.length > 8) {
+      setAlert("nickname");
+      return;
+    }
+
+    // 모든 조건을 통과하면 데이터를 서버로 전송
+    const nextData = {
+      _id: id.value,
+      pw: pw.value,
+      nickname: nickname.value,
+    };
+    const res = await postSignup(nextData);
+
+    // 전송 결과가 already exist면 이미 존재하는 아이디 && id alert 활성화
+    if (res.result === "already exist") {
+      alert("이미 존재하는 아이디입니다.");
+      setAlert("id");
+      return;
+    }
+
+    // 전송 결과가 error이면 서버 에러라고 표기
+    if (res.result === "error") {
+      alert("서버에서의 에러가 발생하였습니다.");
+      return;
+    }
+
+    // 전송 결과가 success면 회원가입 성공
+    alert("회원가입 성공. 다시 로그인 해 주세요");
+    router.push("/signin");
   };
 
   return (

--- a/component/atom/Input/Input.styles.ts
+++ b/component/atom/Input/Input.styles.ts
@@ -1,4 +1,4 @@
-import { ELabelProps, EInputProps, ELineProps } from "type";
+import { ELabelProps, EInputProps, ELineProps, EAlertProps } from "type";
 import styled from "@emotion/styled";
 
 export const Container = styled.div<EInputProps>`
@@ -22,7 +22,7 @@ export const Input = styled.input<EInputProps>`
   font: ${({ theme }) => theme.font["small-light"]};
   font-size: ${({ fontSize }) => fontSize || "13px"};
   border: none;
-  border-bottom: 1px solid;
+  border-bottom: 1px solid ${({ theme }) => theme.color.lightgray};
   outline: none;
   transition: 0.2s ease-in all;
 
@@ -33,10 +33,16 @@ export const Input = styled.input<EInputProps>`
 
 export const Line = styled.div<ELineProps>`
   position: absolute;
-  bottom: -1px;
+  bottom: 16px;
   left: 0;
   width: ${({ isFocus }) => (isFocus ? "100%" : "0")};
   transition: 0.2s ease-in all;
   height: 2px;
   background-color: ${({ theme }) => theme.color.black};
+`;
+
+export const Alert = styled.small<EAlertProps>`
+  font: ${({ theme }) => theme.font["x-small-light"]};
+  color: ${({ theme }) => theme.color.alert};
+  visibility: ${({ isAlert }) => (isAlert ? "visible" : "hidden")};
 `;

--- a/component/atom/Input/Input.tsx
+++ b/component/atom/Input/Input.tsx
@@ -6,6 +6,8 @@ function Input({
   type,
   value,
   onChange,
+  alert,
+  isAlert,
   width,
   fontSize,
   label,
@@ -34,6 +36,7 @@ function Input({
         placeholder={placeholder}
       />
       <S.Line isFocus={isFocus} />
+      <S.Alert isAlert={isAlert}>{alert}</S.Alert>
     </S.Container>
   );
 }

--- a/component/template/Signin/SigninTemplate.tsx
+++ b/component/template/Signin/SigninTemplate.tsx
@@ -21,6 +21,8 @@ function SigninTemplate({
           type="label"
           label="아이디"
           value={id}
+          alert="아이디를 확인해 주세요"
+          isAlert={false}
           onChange={(v: string) => onChange("id", v)}
           placeholder="아이디를 입력해 주세요"
         />
@@ -28,6 +30,8 @@ function SigninTemplate({
           type="label"
           label="비밀번호"
           value={pw}
+          alert="비밀번호를 확인해 주세요"
+          isAlert={false}
           onChange={(v: string) => onChange("pw", v)}
           placeholder="비밀번호를 입력해 주세요"
         />

--- a/component/template/Signin/SigninTemplate.tsx
+++ b/component/template/Signin/SigninTemplate.tsx
@@ -20,18 +20,18 @@ function SigninTemplate({
         <Input
           type="label"
           label="아이디"
-          value={id}
+          value={id.value}
           alert="아이디를 확인해 주세요"
-          isAlert={false}
+          isAlert={id.isAlert}
           onChange={(v: string) => onChange("id", v)}
           placeholder="아이디를 입력해 주세요"
         />
         <Input
           type="label"
           label="비밀번호"
-          value={pw}
+          value={pw.value}
           alert="비밀번호를 확인해 주세요"
-          isAlert={false}
+          isAlert={pw.isAlert}
           onChange={(v: string) => onChange("pw", v)}
           placeholder="비밀번호를 입력해 주세요"
         />

--- a/component/template/Signup/SignupTemplate.styles.ts
+++ b/component/template/Signup/SignupTemplate.styles.ts
@@ -13,7 +13,7 @@ export const Header = styled.div`
   }
 `;
 
-export const Inputs = styled.div`
+export const Form = styled.form`
   display: flex;
   flex-direction: column;
   gap: 20px;

--- a/component/template/Signup/SignupTemplate.tsx
+++ b/component/template/Signup/SignupTemplate.tsx
@@ -9,7 +9,6 @@ function SignupTemplate({
   onSubmit,
 }: ISignupTemplateProps) {
   const { id, pw, pwConfirm, nickname } = inputValues;
-
   return (
     <S.Container>
       <S.Header>
@@ -20,30 +19,38 @@ function SignupTemplate({
         <Input
           type="label"
           label="아이디"
-          value={id}
+          value={id.value}
+          alert="아이디를 확인해 주세요"
+          isAlert={id.isAlert}
           onChange={(v: string) => onChange("id", v)}
-          placeholder="아이디를 입력해 주세요"
+          placeholder="4글자 이상 10글자 이하"
         />
         <Input
           type="label"
           label="비밀번호"
-          value={pw}
+          value={pw.value}
+          alert="비밀번호는 8글자 이상 15글자 이하여야 합니다."
+          isAlert={pw.isAlert}
           onChange={(v: string) => onChange("pw", v)}
-          placeholder="비밀번호를 입력해 주세요"
+          placeholder="8글자 이상 15글자 이하"
         />
         <Input
           type="label"
           label="비밀번호 확인"
-          value={pwConfirm}
+          value={pwConfirm.value}
+          alert="비밀번호가 같은지 확인해 주세요"
+          isAlert={pwConfirm.isAlert}
           onChange={(v: string) => onChange("pwConfirm", v)}
           placeholder="위와 동일한 비밀번호를 입력해 주세요"
         />
         <Input
           type="label"
           label="닉네임"
-          value={nickname}
+          value={nickname.value}
+          alert="닉네임을 확인해 주세요"
+          isAlert={nickname.isAlert}
           onChange={(v: string) => onChange("nickname", v)}
-          placeholder="닉네임을 입력해 주세요"
+          placeholder="2글자 이상 8글자 이하"
         />
       </S.Form>
       <S.Buttons>

--- a/component/template/Signup/SignupTemplate.tsx
+++ b/component/template/Signup/SignupTemplate.tsx
@@ -16,7 +16,7 @@ function SignupTemplate({
         <h1>BOOK STACK</h1>
         <h2>Sign up</h2>
       </S.Header>
-      <S.Inputs>
+      <S.Form onSubmit={onSubmit}>
         <Input
           type="label"
           label="아이디"
@@ -45,7 +45,7 @@ function SignupTemplate({
           onChange={(v: string) => onChange("nickname", v)}
           placeholder="닉네임을 입력해 주세요"
         />
-      </S.Inputs>
+      </S.Form>
       <S.Buttons>
         <RoundButton
           type="line"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.10.6",
         "@emotion/styled": "^11.10.6",
         "@svgr/webpack": "^7.0.0",
+        "axios": "^1.3.4",
         "emotion": "^11.0.0",
         "next": "13.2.4",
         "react": "18.2.0",
@@ -6400,8 +6401,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -6497,6 +6497,29 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -7832,7 +7855,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -8935,7 +8957,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -10812,6 +10833,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -13954,7 +13994,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -13963,7 +14002,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -15797,6 +15835,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/prr": {
       "version": "1.0.1",
@@ -25351,8 +25394,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -25416,6 +25458,28 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.3.tgz",
       "integrity": "sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==",
       "dev": true
+    },
+    "axios": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "axobject-query": {
       "version": "3.1.1",
@@ -26443,7 +26507,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -27324,8 +27387,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "delegates": {
       "version": "1.0.0",
@@ -28846,6 +28908,11 @@
           "dev": true
         }
       }
+    },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -31243,14 +31310,12 @@
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "requires": {
         "mime-db": "1.52.0"
       }
@@ -32653,6 +32718,11 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "prr": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
     "@svgr/webpack": "^7.0.0",
+    "axios": "^1.3.4",
     "emotion": "^11.0.0",
     "next": "13.2.4",
     "react": "18.2.0",

--- a/type/component/atom.d.ts
+++ b/type/component/atom.d.ts
@@ -22,10 +22,15 @@ export interface ELineProps {
   isFocus: boolean;
 }
 
-export interface IInputProps extends EInputProps {
+export interface EAlertProps {
+  isAlert: boolean;
+}
+
+export interface IInputProps extends EInputProps, EAlertProps {
   type: "label" | "default";
   value: string;
   placeholder: string;
+  alert: string;
   onChange: (v: string) => void;
   label?: string;
 }

--- a/type/component/template.d.ts
+++ b/type/component/template.d.ts
@@ -1,23 +1,29 @@
-interface defaultProps {
+interface IValueProps {
+  value: string;
+  isAlert: boolean;
+}
+
+interface ISignupTemplateProps {
+  inputValues: {
+    id: IValueProps;
+    pw: IValueProps;
+    pwConfirm: IValueProps;
+    nickname: IValueProps;
+  };
   onChange: (
     type: "id" | "pw" | "pwConfirm" | "nickname",
     value: string
   ) => void;
   onSubmit: () => void;
 }
-interface ISignupTemplateProps extends defaultProps {
+
+interface ISigninTemplateProps {
   inputValues: {
-    id: { value: string; isAlert: boolean };
-    pw: { value: string; isAlert: boolean };
-    pwConfirm: { value: string; isAlert: boolean };
-    nickname: { value: string; isAlert: boolean };
+    id: IValueProps;
+    pw: IValueProps;
   };
+  onChange: (type: "id" | "pw", value: string) => void;
+  onSubmit: () => void;
 }
 
-interface ISigninTemplateProps extends defaultProps {
-  inputValues: {
-    id: string;
-    pw: string;
-  };
-}
 export type { ISignupTemplateProps, ISigninTemplateProps };

--- a/type/component/template.d.ts
+++ b/type/component/template.d.ts
@@ -1,13 +1,16 @@
 interface defaultProps {
-  onChange: (type: string, value: string) => void;
+  onChange: (
+    type: "id" | "pw" | "pwConfirm" | "nickname",
+    value: string
+  ) => void;
   onSubmit: () => void;
 }
 interface ISignupTemplateProps extends defaultProps {
   inputValues: {
-    id: string;
-    pw: string;
-    pwConfirm: string;
-    nickname: string;
+    id: { value: string; isAlert: boolean };
+    pw: { value: string; isAlert: boolean };
+    pwConfirm: { value: string; isAlert: boolean };
+    nickname: { value: string; isAlert: boolean };
   };
 }
 

--- a/type/index.ts
+++ b/type/index.ts
@@ -4,6 +4,7 @@ import {
   ELabelProps,
   EInputProps,
   ELineProps,
+  EAlertProps,
   IInputProps,
 } from "./component/atom";
 
@@ -18,6 +19,7 @@ export type {
   ELabelProps,
   EInputProps,
   ELineProps,
+  EAlertProps,
   IInputProps,
   ISignupTemplateProps,
   ISigninTemplateProps,


### PR DESCRIPTION
# FE 회원가입 및 로그인 로직 구현

## [ 🛠 FEAT ] 회원가입 로직 구현 : Signup

- Input 값 Check 로직 구현
- Signup POST API 구현
- response에 따른 로직 구현

<img width="365" alt="image" src="https://user-images.githubusercontent.com/97934878/229289775-c2a6d192-2920-43c7-abe1-40ae2ba689c4.png">

<br/>

## [🛠 FEAT ] 회원가입 로직 구현 : Signin

- Input 값 Check 로직 구현
- Signin POST API 구현
- response에 따른 로직 구현
- JWT : localStorage 저장 로직 구현

<img width="369" alt="image" src="https://user-images.githubusercontent.com/97934878/229289789-fa91f046-5e4d-4aab-8068-5bc9e7d30437.png">

<br/>

### 🚀 연관 이슈

close #6 

<br/>
<br/>